### PR TITLE
Fix drush can't be downloaded when there is a broken registry

### DIFF
--- a/github/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
+++ b/github/files/drupal7/scripts/devops/reinstall/sql_workflow.yml
@@ -45,17 +45,23 @@
 # Run registry rebuild.
 - name: Check if registry_rebuild is installed
   shell: "{{ php_env_vars }} drush | grep -c registry_rebuild"
+  args:
+    chdir: ~/
   register: registry_rebuild_installed
   ignore_errors: true
 
 - name: Downloading registry_rebuild
   sudo: yes
   shell: "{{ php_env_vars }} drush -y dl registry_rebuild"
+  args:
+    chdir: ~/  
   when: rebuild_registry and registry_rebuild_installed.stdout == "0"
 
 - name: Clear drush cache
   sudo: yes
   shell: "{{ php_env_vars }} drush cc drush"
+  args:
+    chdir: ~/    
   when: rebuild_registry and registry_rebuild_installed.stdout == "0"
 
 - name: Rebuilding drupal registry


### PR DESCRIPTION
The fix for current stable

How to reproduce:
When SQL flow and new VM is creating there is a situation, when DB has old registry and can't fit new codebase.
So during VM provision and running reinstall - there is a step with downloading registry_rebuild module. But it can't be done, because drush crashes with error.
This patch trying to run download task within user home directory without failing reinstall

@Sanchiz please review. It is simple