### PR TITLE
Fix security review notice

### DIFF
--- a/github/files/drupal7/scripts/devops/roles/cibox-security-testing/tasks/main.yml
+++ b/github/files/drupal7/scripts/devops/roles/cibox-security-testing/tasks/main.yml
@@ -14,4 +14,4 @@
   shell: echo " " >> {{ build_reports_dir }}/SecurityReview.txt
 
 - name: Run Security Review
-  shell: "drush secrev 2>&1 | grep error | tee -a {{ build_reports_dir }}/SecurityReview.txt"
+  shell: "sudo drush secrev 2>&1 | grep error | tee -a {{ build_reports_dir }}/SecurityReview.txt"

--- a/github/files/drupal7/scripts/devops/roles/cibox-security-testing/tasks/main.yml
+++ b/github/files/drupal7/scripts/devops/roles/cibox-security-testing/tasks/main.yml
@@ -14,4 +14,5 @@
   shell: echo " " >> {{ build_reports_dir }}/SecurityReview.txt
 
 - name: Run Security Review
-  shell: "sudo drush secrev 2>&1 | grep error | tee -a {{ build_reports_dir }}/SecurityReview.txt"
+  shell: "drush secrev 2>&1 | grep error | tee -a {{ build_reports_dir }}/SecurityReview.txt"
+  sudo: yes


### PR DESCRIPTION
Fix notice in security report:
```
Directory ~/.drush/cache/default exists, but is not writable. Please check directory permissions.
```