### PR TITLE
Disable Varnish by default and make it more flexible

### DIFF
--- a/github/files/vagrant/box/provisioning/ansible/www.yml
+++ b/github/files/vagrant/box/provisioning/ansible/www.yml
@@ -8,6 +8,7 @@
 
   vars:
     # Varnish configuration.
+    varnish_enabled: false
     # Use this secret in your client(Drupal Varnish module) in order to connect to Varnish.
     varnish_secret: "14bac2e6-1e34-4770-8078-974373b76c90"
 
@@ -39,7 +40,17 @@
       - rewrite.load
       - ssl.load
 
+  # Disable services to avoid conflicts in port usage.
+  pre_tasks:
+    - name: Make sure Varnish is disabled
+      service: name=varnish state=stopped
+      ignore_errors: yes
+
+    - name: Make sure Apache2 is disabled
+      service: name=apache2 state=stopped
+      ignore_errors: yes
+
   roles:
-    - { role: cibox-varnish }
+    - { role: cibox-varnish, when: varnish_enabled }
     - { role: cibox-ssl-config }
     - { role: ansible-role-apache }


### PR DESCRIPTION
This PR allows you disable/enable Varnish "on fly" just by using `vagrant provision` or `vagrant reload --provision`.