### PR TITLE
Clean up ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,192 +1,20 @@
-# config file for ansible -- http://ansible.com/
-# ==============================================
-
-# nearly all parameters can be overridden in ansible-playbook 
-# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# Nearly all parameters can be overridden in ansible-playbook
+# or with command line flags. Ansible will read ANSIBLE_CONFIG,
 # ansible.cfg in the current working directory, .ansible.cfg in
 # the home directory or /etc/ansible/ansible.cfg, whichever it
-# finds first
+# finds first.
+
+# All available settings could be found here:
+# http://docs.ansible.com/ansible/intro_configuration.html
 
 [defaults]
 
-# some basic default values...
-
-hostfile       = ./hosts
-library        = /usr/share/ansible
-remote_tmp     = $HOME/.ansible/tmp
-pattern        = *
-forks          = 5
-poll_interval  = 15
-sudo_user      = root
-#ask_sudo_pass = True
-#ask_pass      = True
-transport      = smart
-remote_port    = 22
-module_lang    = C
-
-# plays will gather facts by default, which contain information about
-# the remote system.
-#
-# smart - gather by default, but don't regather if already gathered
-# implicit - gather by default, turn off with gather_facts: False
-# explicit - do not gather by default, must say gather_facts: True
-gathering = implicit
-
-# additional paths to search for roles in, colon separated
-#roles_path    = /etc/ansible/roles
-
-# uncomment this to disable SSH key host checking
-#host_key_checking = False
-
-# change this for alternative sudo implementations
-sudo_exe = sudo
-
-# what flags to pass to sudo
-#sudo_flags = -H
-
-# SSH timeout
-timeout = 10
-
-# default user to use for playbooks if user is not specified
-# (/usr/bin/ansible will use current user as default)
-#remote_user = root
-
-# logging is off by default unless this path is defined
-# if so defined, consider logrotate
-#log_path = /var/log/ansible.log
-
-# default module name for /usr/bin/ansible
-#module_name = command
-
-# use this shell for commands executed under sudo
-# you may need to change this to bin/bash in rare instances
-# if sudo is constrained
-#executable = /bin/sh
-
-# if inventory variables overlap, does the higher precedence one win
-# or are hash values merged together?  The default is 'replace' but
-# this can also be set to 'merge'.
-#hash_behaviour = replace
-
-# list any Jinja2 extensions to enable here:
-#jinja2_extensions = jinja2.ext.do,jinja2.ext.i18n
-
-# if set, always use this private key file for authentication, same as 
-# if passing --private-key to ansible or ansible-playbook
-#private_key_file = /path/to/file
-
-# format of string {{ ansible_managed }} available within Jinja2 
-# templates indicates to users editing templates files will be replaced.
-# replacing {file}, {host} and {uid} and strftime codes with proper values.
-ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
-
-# by default, ansible-playbook will display "Skipping [host]" if it determines a task
-# should not be run on a host.  Set this to "False" if you don't want to see these "Skipping" 
-# messages. NOTE: the task header will still be shown regardless of whether or not the 
-# task is skipped.
-#display_skipped_hosts = True
-
-# by default (as of 1.3), Ansible will raise errors when attempting to dereference 
-# Jinja2 variables that are not set in templates or action lines. Uncomment this line
-# to revert the behavior to pre-1.3.
-#error_on_undefined_vars = False
-
-# by default (as of 1.6), Ansible may display warnings based on the configuration of the
-# system running ansible itself. This may include warnings about 3rd party packages or
-# other conditions that should be resolved if possible.
-# to disable these warnings, set the following value to False:
-#system_warnings = True
-
-# by default (as of 1.4), Ansible may display deprecation warnings for language
-# features that should no longer be used and will be removed in future versions.
-# to disable these warnings, set the following value to False:
-#deprecation_warnings = True
-
-# set plugin path directories here, separate with colons
-action_plugins     = /usr/share/ansible_plugins/action_plugins
-callback_plugins   = /usr/share/ansible_plugins/callback_plugins
-connection_plugins = /usr/share/ansible_plugins/connection_plugins
-lookup_plugins     = /usr/share/ansible_plugins/lookup_plugins
-vars_plugins       = /usr/share/ansible_plugins/vars_plugins
-filter_plugins     = /usr/share/ansible_plugins/filter_plugins
-
-# don't like cows?  that's unfortunate.
-# set to 1 if you don't want cowsay support or export ANSIBLE_NOCOWS=1 
-#nocows = 1
-
-# don't like colors either?
-# set to 1 if you don't want colors, or export ANSIBLE_NOCOLOR=1
-#nocolor = 1
-
-# the CA certificate path used for validating SSL certs. This path 
-# should exist on the controlling node, not the target nodes
-# common locations:
-# RHEL/CentOS: /etc/pki/tls/certs/ca-bundle.crt
-# Fedora     : /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-# Ubuntu     : /usr/share/ca-certificates/cacert.org/cacert.org.crt
-#ca_file_path = 
-
-# the http user-agent string to use when fetching urls. Some web server
-# operators block the default urllib user agent as it is frequently used
-# by malicious attacks/scripts, so we set it to something unique to 
-# avoid issues.
-#http_user_agent = ansible-agent
-
-[paramiko_connection]
-
-# uncomment this line to cause the paramiko connection plugin to not record new host
-# keys encountered.  Increases performance on new host additions.  Setting works independently of the
-# host key checking setting above.
-#record_host_keys=False
-
-# by default, Ansible requests a pseudo-terminal for commands executed under sudo. Uncomment this
-# line to disable this behaviour.
-#pty=False
-
-[ssh_connection]
-
-# ssh arguments to use
-# Leaving off ControlPersist will result in poor performance, so use 
-# paramiko on older platforms rather than removing it
-#ssh_args = -o ControlMaster=auto -o ControlPersist=60s
-
-# The path to use for the ControlPath sockets. This defaults to
-# "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
-# very long hostnames or very long path names (caused by long user names or 
-# deeply nested home directories) this can exceed the character limit on
-# file socket names (108 characters for most platforms). In that case, you 
-# may wish to shorten the string below.
-# 
-# Example: 
-# control_path = %(directory)s/%%h-%%r
-#control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
-
-# Enabling pipelining reduces the number of SSH operations required to 
-# execute a module on the remote server. This can result in a significant 
-# performance improvement when enabled, however when using "sudo:" you must 
-# first disable 'requiretty' in /etc/sudoers
-#
-# By default, this option is disabled to preserve compatibility with
-# sudoers configurations that have requiretty (the default on many distros).
-# 
-#pipelining = False
-
-# if True, make ansible use scp if the connection type is ssh 
-# (default is sftp)
-#scp_if_ssh = True
+# Deprecated in Ansible 1.9.
+# @todo Use inventory instead.
+hostfile = ./hosts
 
 [accelerate]
-accelerate_port = 5099
-accelerate_timeout = 30
+
+# This setting controls the timeout for the socket connect call, and should be
+# kept relatively low. Default value is 1.0.
 accelerate_connect_timeout = 5.0
-
-# The daemon timeout is measured in minutes. This time is measured
-# from the last activity to the accelerate daemon.
-accelerate_daemon_timeout = 30 
-
-# If set to yes, accelerate_multi_key will allow multiple
-# private keys to be uploaded to it, though each user must
-# have access to the system via SSH to add a new key. The default
-# is "no".
-#accelerate_multi_key = yes
-


### PR DESCRIPTION
Currently, `config.cfg` file is terrificly huge and not user friendly at all. It has a lot of redundant comments and commented settings. It's really hard to grasp what's going on there.

I propose to put there only the settings which are different from the default ones.

I've done a research for each item which I removed from the file. So, basically nothing was changed. 