### PR TITLE
Ignore docroot/build-reports dir

### DIFF
--- a/github/files/vagrant/box/.gitignore
+++ b/github/files/vagrant/box/.gitignore
@@ -3,3 +3,4 @@
 .vagrant
 backup
 index.html
+docroot/build_reports


### PR DESCRIPTION
Hi. I think its necessary to hide docroot/build_reports directory that appears after sniffering process.