### PR TITLE
Replace grep with perl to get IP from config.yml

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,6 @@
 export PYTHONUNBUFFERED=1
 
 # Get server IP from config.yml
-REGEX_IP="(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
-IP=`cat config.yml | grep -oP "^server_ip:\s*$REGEX_IP" | grep -oP "$REGEX_IP"`
+IP=`perl -ne '/^server_ip:\s((?:[0-9]{1,3}\.){3}[0-9]{1,3})/ && print "$1"' config.yml`
 
 ansible-playbook -vvvv -i $IP, jenkinsbox.yml --extra-vars "@config.yml"


### PR DESCRIPTION
Fix `run.sh` to work on Mac.

How to review:

1. Open you Mac.
2. Edit config.yml and provide the IP of your server.
3. Execute command ./run.sh and make your coffee.
4. Get your Jenkins server!