### PR TITLE
Additional cleanup for repeated reinstall of ansible roles

### DIFF
--- a/core/cibox-env/tasks/main.yml
+++ b/core/cibox-env/tasks/main.yml
@@ -49,3 +49,8 @@
   pip: name={{ item }} state=present
   sudo: yes
   with_items: pip_packages
+
+- name: Remove premature repository from php role
+  sudo: yes
+  action: apt_repository repo='ppa:ondrej/php5-5.6' state=absent
+  ignore_errors: yes


### PR DESCRIPTION
Repo from php role messes up apache installation:
apache2-mpm-prefork : Depends: apache2 (= 2.4.7-1ubuntu4.9) but 2.4.18-1+deb.sury.org~trusty+2 is to be installed

apt-cache output:
apache2:
  Installed: (none)
  Candidate: 2.4.18-1+deb.sury.org~trusty+2
  Version table:
     2.4.18-1+deb.sury.org~trusty+2 0
        500 http://ppa.launchpad.net/ondrej/php5-5.6/ubuntu/ trusty/main amd64 Packages
     2.4.7-1ubuntu4.9 0
        500 http://mirrors.digitalocean.com/ubuntu/ trusty-updates/main amd64 Packages
     2.4.7-1ubuntu4.5 0
        500 http://security.ubuntu.com/ubuntu/ trusty-security/main amd64 Packages
     2.4.7-1ubuntu4 0
        500 http://mirrors.digitalocean.com/ubuntu/ trusty/main amd64 Packages

Can be reproduced by repeated install of Jenkins playbook(whether due to other installation errors, or during upgrade from previous Cibox version).