### PR TITLE
Add -n option to runsniffers.sh

### DIFF
--- a/docs/usage/Check-your-code-with-sniffers.md
+++ b/docs/usage/Check-your-code-with-sniffers.md
@@ -1,0 +1,9 @@
+Check your code with sniffers
+=====
+
+To check your code with sniffers use `runsniffers.sh` command whithin `/var/www/docroot` directory.
+If you do not want to update software every time and save your time, plese use `-n` argument. *Note*, the first run of the command should be without any arguments to download the dependencies.
+Example:
+```
+./runsniffers.sh -n
+```

--- a/github/files/drupal7/scripts/runsniffers.sh
+++ b/github/files/drupal7/scripts/runsniffers.sh
@@ -1,9 +1,27 @@
 #!/bin/sh
-# You should install ansible for ability to run this script
-# sudo apt-get install software-properties-common
-# sudo apt-add-repository ppa:ansible/ansible
-# sudo apt-get update
-# sudo apt-get install ansible
-# sudo apt-get install python-mysqldb
-export PYTHONUNBUFFERED=1
-time ansible-playbook -vvvv sniffers.yml -i 'localhost,' --connection=local
+
+#
+# Sniffers Runner
+#
+# This script runs Ansible sniffers.yml Ansible playbook.
+# Use "-n" option to prevent the playbook from updating software each time.
+# Example: ./runsniffers.sh -n
+
+UPDATE=1
+while getopts ":n" opt; do
+  case $opt in
+    n)
+	  UPDATE=0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+
+if [ $UPDATE -eq 1 ]
+then
+  time ansible-playbook -vvvv sniffers.yml -i 'localhost,' --connection=local
+else
+  time ansible-playbook -vvvv sniffers.yml -i 'localhost,' --connection=local --extra-vars "sniffers_update=false"
+fi

--- a/github/files/drupal7/scripts/sniffers.yml
+++ b/github/files/drupal7/scripts/sniffers.yml
@@ -72,146 +72,157 @@
     scsslint_folders:
       - { name: 'themes', path: 'sites/all/themes/custom' }
 
+    sniffers_update: true
+
   roles:
     - { role: devops/roles/cibox-security-testing, when: scan_security == true }
 
   pre_tasks:
+    - name: Was composer downloaded
+      sudo: yes
+      stat: path={{ composer_dir }}
+      register: is_composer_dir
+      when: sniffers_update == true
 
-  - name: Was composer downloaded
-    sudo: yes
-    stat: path={{ composer_dir }}
-    register: is_composer_dir
+    - name: Install apt repos
+      apt_repository: repo={{ item }}
+      with_items: sniffers_apt_repos
+      sudo: yes
+      when: sniffers_update == true
+      tags:
+        - nodejs
 
-  - name: Install apt repos
-    apt_repository: repo={{ item }}
-    with_items: sniffers_apt_repos
-    sudo: yes
-    tags:
-      - nodejs
+    - name: Update apt cache
+      sudo: yes
+      apt: update_cache=yes
+      ignore_errors: yes
+      when: sniffers_update == true
 
-  - name: Update apt cache
-    sudo: yes
-    apt: update_cache=yes
-    ignore_errors: yes
+    - name: Install apt packages
+      apt: name={{ item }} state=present
+      with_items: sniffers_apt_packages
+      sudo: yes
+      when: sniffers_update == true
+      tags:
+        - sniffers
+        - composer
+        - git
 
-  - name: Install apt packages
-    apt: name={{ item }} state=present
-    with_items: sniffers_apt_packages
-    sudo: yes
-    tags:
-      - sniffers
-      - composer
-      - git
+    - name: prepare directory for global composer libs
+      sudo: yes
+      file: path={{ composer_dir }} state=directory
+      when: sniffers_update == true and is_composer_dir.stat.exists == false
+      tags:
+        - sniffers
 
-  - name: Prepare directory for global composer libs
-    sudo: yes
-    file: path={{ composer_dir }} state=directory
-    when: is_composer_dir.stat.exists == false
-    tags:
-      - sniffers
+    - name: Install composer global requires
+      sudo: yes
+      shell: "cd {{ composer_dir }} && composer require --prefer-dist {{ item }}"
+      with_items: composer_global_require
+      when: sniffers_update == true
+      tags:
+        - sniffers
+        - composer
+        - git
 
-  - name: Install composer global requires
-    sudo: yes
-    shell: "cd {{ composer_dir }} && composer require --prefer-dist {{ item }}"
-    with_items: composer_global_require
-    tags:
-      - sniffers
-      - composer
-      - git
+    - name: Install global git repos
+      sudo: yes
+      git: repo={{ item.repo }} dest={{ composer_dir }}/vendor/podarok/{{ item.name }} version={{ item.branch }}
+      with_items: git_repos
+      when: sniffers_update == true
+      tags:
+        - sniffers
+        - git
 
-  - name: Install global git repos
-    sudo: yes
-    git: repo={{ item.repo }} dest={{ composer_dir }}/vendor/podarok/{{ item.name }} version={{ item.branch }}
-    with_items: git_repos
-    #ignore_errors: yes
-    tags:
-      - sniffers
-      - git
+    - name: Install php codesniffer standards
+      sudo: yes
+      file: src={{ composer_dir }}/{{ item.path }} dest={{ composer_dir }}/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/{{ item.name }} state=link
+      with_items: phpcs_standards
+      when: sniffers_update == true
+      tags:
+        - sniffers
+        - git
 
-  - name: Install php codesniffer standards
-    sudo: yes
-    file: src={{ composer_dir }}/{{ item.path }} dest={{ composer_dir }}/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/{{ item.name }} state=link
-    with_items: phpcs_standards
-    tags:
-      - sniffers
-      - git
+    - name: Fix permissions for composer libs
+      sudo: yes
+      file: path={{ composer_dir }} state=directory mode=655 recurse=yes
+      when: sniffers_update == true
 
-  - name: Fix permissions for composer libs
-    sudo: yes
-    file: path={{ composer_dir }} state=directory mode=655 recurse=yes
+    - name: Create symlink to phpcs binary
+      sudo: yes
+      file: src={{ composer_dir }}/vendor/bin/phpcs dest={{ phpcs_bin }} state=link mode=655 force=yes
+      when: sniffers_update == true
 
-  - name: Create symlink to phpcs binary
-    sudo: yes
-    file: src={{ composer_dir }}/vendor/bin/phpcs dest={{ phpcs_bin }} state=link mode=655 force=yes
+    - name: Install nodejs packages
+      sudo: yes
+      npm: name={{ item }} global=yes
+      with_items: npm_packages
+      when: sniffers_update == true
 
-  - name: Install nodejs packages
-    sudo: yes
-    npm: name={{ item }} global=yes
-    with_items: npm_packages
+    - name: Update ruby alternatives for using ruby 1.9.1(3) version
+      sudo: yes
+      shell: "update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby1.9.1 400 --slave /usr/share/man/man1/ruby.1.gz ruby.1.gz /usr/share/man/man1/ruby1.9.1.1.gz --slave /usr/bin/ri ri /usr/bin/ri1.9.1 --slave /usr/bin/irb irb /usr/bin/irb1.9.1 --slave /usr/bin/rdoc rdoc /usr/bin/rdoc1.9.1"
+      when: sniffers_update == true and is_composer_dir.stat.exists == false
+      tags:
+        - sniffers
+        - ruby
 
-  - name: Update ruby alternatives for using ruby 1.9.1(3) version
-    sudo: yes
-    shell: "update-alternatives --install /usr/bin/ruby ruby /usr/bin/ruby1.9.1 400 --slave /usr/share/man/man1/ruby.1.gz ruby.1.gz /usr/share/man/man1/ruby1.9.1.1.gz --slave /usr/bin/ri ri /usr/bin/ri1.9.1 --slave /usr/bin/irb irb /usr/bin/irb1.9.1 --slave /usr/bin/rdoc rdoc /usr/bin/rdoc1.9.1"
-    when: is_composer_dir.stat.exists == false
-    tags:
-      - sniffers
-      - ruby
-
-  - name: Install gem packages
-    shell: "gem install {{ item }}"
-    with_items: gem_packages
-    ignore_errors: yes
-    sudo: yes
-    tags:
-      - sniffers
-      - gem
-      - ruby
-
-  - name: Create directory for build reports
-    sudo: yes
-    file: path={{ build_reports_dir }} state=directory mode=0777
+    - name: Install gem packages
+      shell: "gem install {{ item }}"
+      with_items: gem_packages
+      ignore_errors: yes
+      sudo: yes
+      when: sniffers_update == true
+      tags:
+        - sniffers
+        - gem
+        - ruby
 
   tasks:
-  - name: PHP CodeSniffer run
-    shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_extensions }} -n {{ custom_modules_path }} {{ installation_profile_path }} {{ custom_themes_path }} --report-file={{ build_reports_dir }}/{{ item.name }}sniff.txt --ignore={{ phpcs_modules_ignore | join(",") }} || true'
-    with_items: phpcs_standards
+    - name: Create directory for build reports
+      sudo: yes
+      file: path={{ build_reports_dir }} state=directory mode=0777
 
-  - name: PHP CodeSniffer reports build
-    ignore_errors: yes
-    shell: 'if grep "FOUND" {{ build_reports_dir }}/{{ item.name }}sniff.txt; then echo "<strong>`grep -o "\<\| ERROR \|\>" {{ build_reports_dir }}/{{ item.name }}sniff.txt | wc -l`</strong>  errors for CodeSniffer: {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/{{ item.name }}sniff.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi;'
-    with_items: phpcs_standards
+    - name: PHP CodeSniffer run
+      shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_extensions }} -n {{ custom_modules_path }} {{ installation_profile_path }} {{ custom_themes_path }} --report-file={{ build_reports_dir }}/{{ item.name }}sniff.txt --ignore={{ phpcs_modules_ignore | join(",") }} || true'
+      with_items: phpcs_standards
 
-  - name: Security Review report build
-    ignore_errors: yes
-    shell: 'if grep "error" {{ build_reports_dir }}/SecurityReview.txt; then echo "<strong>`grep -o "\<error\>" {{ build_reports_dir }}/SecurityReview.txt | wc -l`</strong>  errors for Security Review: Security Review standard file {{ webroot }}/{{ build_reports_dir }}/SecurityReview.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi;'
+    - name: PHP CodeSniffer reports build
+      ignore_errors: yes
+      shell: 'if grep "FOUND" {{ build_reports_dir }}/{{ item.name }}sniff.txt; then echo "<strong>`grep -o "\<\| ERROR \|\>" {{ build_reports_dir }}/{{ item.name }}sniff.txt | wc -l`</strong>  errors for CodeSniffer: {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/{{ item.name }}sniff.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi;'
+      with_items: phpcs_standards
 
-  - name: PHP CodeSniffer for features run
-    shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_features_extensions }} -n {{ features_path }} --report-file={{ build_reports_dir }}/Features{{ item.name }}sniff.txt --ignore={{ phpcs_features_ignore | join(",") }} || true'
-    with_items: phpcs_standards
+    - name: Security Review report build
+      ignore_errors: yes
+      shell: 'if grep "error" {{ build_reports_dir }}/SecurityReview.txt; then echo "<strong>`grep -o "\<error\>" {{ build_reports_dir }}/SecurityReview.txt | wc -l`</strong>  errors for Security Review: Security Review standard file {{ webroot }}/{{ build_reports_dir }}/SecurityReview.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi;'
 
-  - name: PHP CodeSniffer for features reports build
-    ignore_errors: yes
-    shell: 'if grep "FOUND" {{ build_reports_dir }}/Features{{ item.name }}sniff.txt; then echo "<strong>`grep -o "\<\| ERROR \|\>" {{ build_reports_dir }}/Features{{ item.name }}sniff.txt | wc -l`</strong> errors for CodeSniffer: Features {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/Features{{ item.name }}sniff.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
-    with_items: phpcs_standards
+    - name: PHP CodeSniffer for features run
+      shell: '{{ phpcs_bin }} --standard={{ item.name }} --extensions={{ phpcs_features_extensions }} -n {{ features_path }} --report-file={{ build_reports_dir }}/Features{{ item.name }}sniff.txt --ignore={{ phpcs_features_ignore | join(",") }} || true'
+      with_items: phpcs_standards
 
-  - name: JSHint run
-    shell: 'find {{ item.path }} ! -path "*mute*" -type f \( -iname "*.js" ! -iname "*min.js" \) -print0 | sudo xargs -0 jshint > {{ build_reports_dir }}/{{ item.name }}jshint.txt || true'
-    with_items: jshint_folders
+    - name: PHP CodeSniffer for features reports build
+      ignore_errors: yes
+      shell: 'if grep "FOUND" {{ build_reports_dir }}/Features{{ item.name }}sniff.txt; then echo "<strong>`grep -o "\<\| ERROR \|\>" {{ build_reports_dir }}/Features{{ item.name }}sniff.txt | wc -l`</strong> errors for CodeSniffer: Features {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/Features{{ item.name }}sniff.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
+      with_items: phpcs_standards
 
-  - name: JSHint build reports
-    ignore_errors: yes
-    shell: 'if [ -s {{ build_reports_dir }}/{{ item.name }}jshint.txt ]; then echo "<strong>`wc -l < {{ build_reports_dir }}/{{ item.name }}jshint.txt`</strong> JSHint: {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/{{ item.name }}jshint.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
-    with_items: jshint_folders
+    - name: JSHint run
+      shell: 'find {{ item.path }} ! -path "*mute*" -type f \( -iname "*.js" ! -iname "*min.js" \) -print0 | sudo xargs -0 jshint > {{ build_reports_dir }}/{{ item.name }}jshint.txt || true'
+      with_items: jshint_folders
 
-  - name: SCSS lint run
-    shell: 'find {{ item.path }} -name "*.scss" -print0 | xargs -0 -r scss-lint -c scss-lint.yml > {{ build_reports_dir }}/scsslint{{ item.name }}.txt || true'
-    with_items: scsslint_folders
+    - name: JSHint build reports
+      ignore_errors: yes
+      shell: 'if [ -s {{ build_reports_dir }}/{{ item.name }}jshint.txt ]; then echo "<strong>`wc -l < {{ build_reports_dir }}/{{ item.name }}jshint.txt`</strong> JSHint: {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/{{ item.name }}jshint.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
+      with_items: jshint_folders
 
-  - name: SCSS lint build reports
-    ignore_errors: yes
-    shell: 'if grep -o "\<[E]\>" {{ build_reports_dir }}/scsslint{{ item.name }}.txt; then echo "<strong>`grep -o "\<[E]\>" {{ build_reports_dir }}/scsslint{{ item.name }}.txt | wc -l`</strong> errors for SCSS-lint {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/scsslint{{ item.name }}.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
-    with_items: scsslint_folders
+    - name: SCSS lint run
+      shell: 'find {{ item.path }} -name "*.scss" -print0 | xargs -0 -r scss-lint -c scss-lint.yml > {{ build_reports_dir }}/scsslint{{ item.name }}.txt || true'
+      with_items: scsslint_folders
 
-  - name: Website credentials
-    sudo: yes
-    lineinfile: dest={{ workspace_root }}/{{ artifacts_file }} line="Build site installed at {{ webroot }}" create=yes state=present
+    - name: SCSS lint build reports
+      ignore_errors: yes
+      shell: 'if grep -o "\<[E]\>" {{ build_reports_dir }}/scsslint{{ item.name }}.txt; then echo "<strong>`grep -o "\<[E]\>" {{ build_reports_dir }}/scsslint{{ item.name }}.txt | wc -l`</strong> errors for SCSS-lint {{ item.name }} standard file {{ webroot }}/{{ build_reports_dir }}/scsslint{{ item.name }}.txt" >> {{ workspace_root }}/{{ artifacts_file }} && exit 1; fi'
+      with_items: scsslint_folders
+
+    - name: Website credentials
+      sudo: yes
+      lineinfile: dest={{ workspace_root }}/{{ artifacts_file }} line="Build site installed at {{ webroot }}" create=yes state=present


### PR DESCRIPTION
A motivation:

Currently, if a developer wants to check the code with sniffers and runs runsniffers.sh command he has to wait up to 5-7 minutes, depending on the internet connections.

I strongly believe we could save a lot of developer's time by providing a flag which will prevent runsniffers.sh command update software every time.

How to review:

1. Create VM
2. Run `reinstall.sh`
3. Add some code to check
4. Run `runsniffers.sh`
5. Run `runsniffers.sh -n`
6. Make sure the the code was checked. 

