### PR TITLE
Fix annoying issue with broken apt repos

### DIFF
--- a/core/cibox-env/tasks/main.yml
+++ b/core/cibox-env/tasks/main.yml
@@ -33,9 +33,11 @@
   apt_repository: repo={{ item }} validate_certs=no
   with_items: apt_repos
 
+
 - name: Update apt
   apt: update_cache=yes
   sudo: yes
+  ignore_errors: yes
 
 - name: Install packages
   shell: apt-get -y install {{ apt_packages|selectattr('status', 'equalto', true)|map(attribute='name')|join(' ') }}

--- a/core/cibox-env/tasks/main.yml
+++ b/core/cibox-env/tasks/main.yml
@@ -33,7 +33,6 @@
   apt_repository: repo={{ item }} validate_certs=no
   with_items: apt_repos
 
-
 - name: Update apt
   apt: update_cache=yes
   sudo: yes


### PR DESCRIPTION
Sometimes apt-get update failing because of internet access.
Let's ignore as not necessary to get all repos updated for continue