### PR TITLE
Fix for Google Chrome apt repo

### DIFF
--- a/core/cibox-behat-selenium2/tasks/main.yml
+++ b/core/cibox-behat-selenium2/tasks/main.yml
@@ -5,7 +5,7 @@
   tags: behat-selenium
 
 - name: Adding Chrome APT repo to local database
-  shell: sh -c 'echo deb http://dl.google.com/linux/chrome/deb/ stable main > /etc/apt/sources.list.d/google.list'
+  shell: sh -c 'echo deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main > /etc/apt/sources.list.d/google.list'
   tags: behat-selenium
 
 - name: Install dependencies


### PR DESCRIPTION
32-bit version of Google Chrome is no longer supported.

http://www.omgubuntu.co.uk/2016/03/fix-failed-to-fetch-google-chrome-apt-error-ubuntu
http://askubuntu.com/questions/741850/repository-failure-with-google-chrome