### PR TITLE
#413: Use Drush 8 by default

### DIFF
--- a/core/cibox-project-builder/files/vagrant/box/provisioning/ansible/playbooks/drush.yml
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/ansible/playbooks/drush.yml
@@ -9,10 +9,7 @@
     - { role: '../core/cibox-drush' }
 
   vars:
-    # Drush for Drupal 7.
-    drush_composer_version: 6.*
-    # Drush for Drupal 8.
-    # drush_composer_version: 8.*
+    drush_composer_version: 8.*
     drushrc:
       drush_usage_log: 1
       drush_usage_send: 1

--- a/services/jenkinsbox.yml
+++ b/services/jenkinsbox.yml
@@ -5,10 +5,7 @@
   remote_user: root
 
   vars:
-    # Drush for Drupal 7.
-    drush_composer_version: 6.*
-    # Drush for Drupal 8.
-    # drush_composer_version: 8.*
+    drush_composer_version: 8.*
 
     drushrc:
       drush_usage_log: 1


### PR DESCRIPTION
Issue #413: Since Drush 8 is compatible with D6, D7, D8 - let's use it by default.
![image](https://cloud.githubusercontent.com/assets/1316234/14889102/1190eaa4-0d66-11e6-9a67-b0e549026a43.png)
