### PR TITLE
Fix for python pip dependencies - ffi, ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Want to hack on CIBox? Awesome! We have [instructions to help you get started co
 These instructions are probably not perfect, please let us know if anything feels wrong or incomplete. Better yet, submit a PR and improve them yourself.
 
 ## Contacts
-Follow us on [Twitter](https://twitter.com/cibox_tools) and [FaceBook](https://www.facebook.com/CIBox-178038095885249/)
+Follow us on [Twitter](https://twitter.com/cibox_tools) and [FaceBook](https://www.facebook.com/CIBox.tools)

--- a/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
@@ -17,9 +17,11 @@ echo 'Installing ansible'
 
 echo "Installing pip via easy_install."
 sudo apt-get -y --force-yes install python-pip python-dev build-essential
+sudo apt-get install libffi-dev
 sudo pip install --upgrade pip 
 sudo pip install --upgrade virtualenv 
 sudo pip install --upgrade pip
+sudo pip install --upgrade cffi 
 # Make sure setuptools are installed correctly.
 pip install setuptools --no-use-wheel --upgrade
 

--- a/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
@@ -16,8 +16,8 @@ echo 'Finished installing base packages for ansible'
 echo 'Installing ansible'
 
 echo "Installing pip via easy_install."
-sudo apt-get -y --force-yes install python-pip python-dev build-essential
-sudo apt-get install libffi-dev
+sudo apt-get -y --force-yes install python-pip python-dev build-essential libffi-dev
+
 sudo pip install --upgrade pip 
 sudo pip install --upgrade virtualenv 
 sudo pip install --upgrade pip

--- a/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
@@ -16,7 +16,7 @@ echo 'Finished installing base packages for ansible'
 echo 'Installing ansible'
 
 echo "Installing pip via easy_install."
-sudo apt-get -y --force-yes install python-pip python-dev build-essential libffi-dev
+sudo apt-get -y --force-yes install python-pip python-dev build-essential libffi-dev libssl-dev
 
 sudo pip install --upgrade pip 
 sudo pip install --upgrade virtualenv 

--- a/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
@@ -22,6 +22,7 @@ sudo pip install --upgrade pip
 sudo pip install --upgrade virtualenv 
 sudo pip install --upgrade pip
 sudo pip install --upgrade cffi 
+sudo pip install --upgrade cryptography
 # Make sure setuptools are installed correctly.
 pip install setuptools --no-use-wheel --upgrade
 


### PR DESCRIPTION
per @boyanborisov request

```
==> default:     creating build/temp.linux-x86_64-2.7
==> default:     creating build/temp.linux-x86_64-2.7/c
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DUSE__THREAD -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python2.7 -c c/_cffi_backend.c -o build/temp.linux-x86_64-2.7/c/_cffi_backend.o
==> default:     c/_cffi_backend.c:15:17: fatal error: ffi.h: No such file or directory
==> default:      #include <ffi.h>
==> default:                      ^
==> default:     compilation terminated.
==> default:     error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

```
==> default:     creating build/temp.linux-x86_64-2.7/build
==> default:     creating build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7
==> default:     x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include/python2.7 -c build/temp.linux-x86_64-2.7/_openssl.c -o build/temp.linux-x86_64-2.7/build/temp.linux-x86_64-2.7/_openssl.o
==> default:     build/temp.linux-x86_64-2.7/_openssl.c:423:27: fatal error: openssl/e_os2.h: No such file or directory
==> default:      #include <openssl/e_os2.h>
==> default:                                ^
==> default:     compilation terminated.
==> default:     error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```
