### PR TITLE
Python version 2.7.9.

### DIFF
--- a/core/cibox-env/defaults/main.yml
+++ b/core/cibox-env/defaults/main.yml
@@ -17,7 +17,7 @@ apt_packages:
   - { name: "python-software-properties", status: true }
   - { name: "python-dev", status: true }
   - { name: "python-setuptools", status: true }
-  - { name: "python", status: true }
+  - { name: "python=2.7.9", status: true }
   - { name: "python-simplejson", status: true }
   - { name: "python-passlib", status: true }
   - { name: "software-properties-common", status: true }

--- a/core/cibox-env/defaults/main.yml
+++ b/core/cibox-env/defaults/main.yml
@@ -17,7 +17,7 @@ apt_packages:
   - { name: "python-software-properties", status: true }
   - { name: "python-dev", status: true }
   - { name: "python-setuptools", status: true }
-  - { name: "python=2.7.9", status: true }
+  - { name: "python", status: true }
   - { name: "python-simplejson", status: true }
   - { name: "python-passlib", status: true }
   - { name: "software-properties-common", status: true }

--- a/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
+++ b/core/cibox-project-builder/files/vagrant/box/provisioning/shell/ansible.sh
@@ -2,8 +2,10 @@
 
 echo 'Installing base packages for ansible'
 export "DEBIAN_FRONTEND=noninteractive"
-# ansible needs python.
-apt-get -y --force-yes install python python-dev python-simplejson sudo curl make rsync git libmysqlclient-dev apparmor-utils >/dev/null
+# ansible needs python version 2.7.9 to avoid SNIMissingWarning.
+# see http://urllib3.readthedocs.io/en/latest/security.html#snimissingwarning
+apt-get -y --force-yes install python 2.7.9
+apt-get -y --force-yes install python-dev python-simplejson sudo curl make rsync git libmysqlclient-dev apparmor-utils >/dev/null
 
 # because basic ubuntu is too stripped down we need to add logging.
 apt-get --reinstall install -y --force-yes bsdutils >/dev/null


### PR DESCRIPTION
Currently when I provision vagrant box I get error:

==> default: /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:315: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#snimissingwarning.

This PR to fix the issue by specifying version of the python.